### PR TITLE
remove experimental pip install syntax

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,8 +55,3 @@ jobs:
         run: |
           python setup.py sdist bdist_wheel
           pip uninstall -y mud
-
-      - name: Test install with other syntax
-        run: |
-          pip install . --use-feature=in-tree-build
-          # python -m build .  # for future inclusion of pyproject.toml with pyscaffold v5+


### PR DESCRIPTION
this updates your main branch so that the checks on the PR will pass. 

pip finally removed some experimental syntax and it broke my CI tests since I was making sure I would be able to handle it if the change actually ended up being adopted. 